### PR TITLE
Alias and remove empty data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added `remove_empty_data` flag - If set & true it causes removal of empty key/value pairs from filtered input data.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ behavior:
 - `allows_only_fields_in_filter`: if present, and `use_raw_data` is boolean false, the value of this
   flag will define whether or not additional fields present in the payload will be merged with the
   filtered data.
+  
+- `remove_empty_data`: Should we remove empty data from received data?
+  - If no `remove_empty_data` flag is present, do nothing - use data as is
+  - If `remove_empty_data` flag is present AND is boolean true, then remove
+    empty data from current data array
 
 > ### Validating GET requests
 >

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -78,6 +78,11 @@ return [
          *   boolean false, the value of this flag will define whether or
          *   not additional fields present in the payload will be merged
          *   with the filtered data.
+         *
+         * - remove_empty_data: Should we remove empty data from received data?
+         *   - If no `remove_empty_data` flag is present, do nothing - use data as is
+         *   - If `remove_empty_data` flag is present AND is boolean true, then remove
+         *     empty data from current data array
          */
     ],
 ];

--- a/src/ContentValidationListener.php
+++ b/src/ContentValidationListener.php
@@ -375,10 +375,8 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
             || (isset($this->config[$controllerService]['remove_empty_data'])
                 && $this->config[$controllerService]['remove_empty_data'] === true)
         ) {
-
             return true;
         }
-
         return false;
     }
 
@@ -390,7 +388,6 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
     {
         $data = array_filter($data);
         if (empty($data)) {
-
             return $data;
         }
 
@@ -407,7 +404,6 @@ class ContentValidationListener implements ListenerAggregateInterface, EventMana
                 }
             }
         }
-
         return $data;
     }
 


### PR DESCRIPTION
Updated removeEmptyData in ContentValidationListener to perform additional checks for empty data on response of recursive calls to prevent possibility of returned empty array being left in final response.